### PR TITLE
Yield Chain-wrapped items from Chain.__iter__

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,20 @@ print(data.missing / 0)  # 0
 Daisies allows you to work with lists, sets, and other iterables in a natural way.
 You can access items by index and iterate over them. If they don't exist, Daisies will return `None`.
 
+Iterating a `Chain` yields `Chain`-wrapped items, so you can keep navigating each element safely inside the loop — no need to unwrap and re-wrap. Missing fields on an element still resolve to `None` instead of raising.
 
 ```python
 data = Chain({
-    "names": ["Alice", "Bob", "Charlie"]
+    "names": ["Alice", "Bob", "Charlie"],
+    "users": [{"name": "Alice"}, {"name": "Bob"}]
 })
 
 print(data.names[0])  # "Alice"
 print(data.names[50])  # None
 
-for index, name in enumerate(data.names):
-    print(name)
+# Each item is a Chain, so nested access keeps working through the loop:
+for user in data.users:
+    print(user.name)  # "Alice", then "Bob"
 ```
 
 ### Working with dicts and nested data

--- a/daisies/chain.py
+++ b/daisies/chain.py
@@ -115,9 +115,14 @@ class Chain:
 
         return Chain(item)
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[Chain]:
+        # Yield wrapped items so navigation continues through a loop without
+        # re-wrapping (e.g. ``for row in chain.users: row.name``). Wrapped items
+        # still compare equal to their raw values, so ``sorted``/``==``/``in``
+        # keep working. Returning None for non-iterables makes ``iter()`` raise
+        # TypeError just as before (a generator function wouldn't — it defers).
         if isiterable(self._wrapped):
-            return iter(self._wrapped)
+            return (Chain(item) for item in self._wrapped)
 
         return None  # type: ignore[return-value]
 

--- a/daisies/tests/test_iterables.py
+++ b/daisies/tests/test_iterables.py
@@ -29,6 +29,21 @@ class TestIterables(unittest.TestCase):
         for index, item in enumerate(wrapped):
             assert index + 1 == item
 
+    def test_iteration_yields_wrapped_items(self):
+        # Iterating keeps you in Chain-land, so navigation continues through a
+        # loop without re-wrapping; missing fields inside still resolve to None.
+        data = Chain({"users": [{"name": "Ada"}, {"name": "Bob"}, {}]})
+        for item in data.users:
+            assert isinstance(item, Chain)
+        assert [user.name.value() for user in data.users] == ["Ada", "Bob", None]
+
+    def test_iterated_scalars_compare_equal_to_raw(self):
+        # Wrapped items compare equal to their raw values, so sorted/==/in keep
+        # working unchanged after the wrapping fix.
+        wrapped = Chain([3, 1, 2])
+        assert [item for item in wrapped] == [3, 1, 2]
+        assert sorted(wrapped) == [1, 2, 3]
+
     def test_sets(self):
         assert Chain(set()) == set()
         assert Chain({1, 2, 3}) == {1, 2, 3}

--- a/daisies/tests/test_readme.py
+++ b/daisies/tests/test_readme.py
@@ -44,9 +44,16 @@ class TestReadmeExamples(unittest.TestCase):
         assert data.missing / 0 == 0
 
     def test_lists(self):
-        data = Chain({"names": ["Alice", "Bob", "Charlie"]})
+        data = Chain(
+            {
+                "names": ["Alice", "Bob", "Charlie"],
+                "users": [{"name": "Alice"}, {"name": "Bob"}],
+            }
+        )
         assert data.names[0] == "Alice"
         assert data.names[50]() is None
+        # Iterating yields Chains, so nested access keeps working in the loop.
+        assert [user.name.value() for user in data.users] == ["Alice", "Bob"]
 
     def test_nested_dicts(self):
         data = Chain(


### PR DESCRIPTION
## What
`Chain.__iter__` now yields `Chain`-wrapped items instead of the raw underlying values.

## Why
Iterating a `Chain` previously yielded raw items, so safe navigation broke inside loops:

```python
for row in chain.users:
    row.name          # AttributeError: 'dict' object has no attribute 'name'
```

…which forced a manual `Chain(row)` re-wrap. This was the one place `Chain` broke its own "everything stays wrapped until you unwrap" invariant — `chain.users[0]` already returns a `Chain`, so iteration should too.

```python
for row in chain.users:
    row.name.value()  # just works now
```

## Behavior change
`list(chain)` and `"".join(chain)` now yield/operate on `Chain`es; use `.list()` / `.value()` / `.json()` for raw output. This is consistent with indexed access, which already returns `Chain`es. Worth a minor-version bump + changelog note.

## Compatibility kept
- Wrapped items compare equal to and order against their raw values → `sorted()` / `==` / `in` / `enumerate` unchanged.
- Non-iterables still raise `TypeError` from `iter()` — kept the `None` return rather than switching to a generator function, which would defer the error.
- `.list()` / `.dict()` / `.json()` still return raw data; they unwrap `self._wrapped` directly.
- Lazy: the generator expression wraps one item at a time, so no extra copy of large lists.

## Tests
+2 iteration tests pinning the new behavior and the backward-compat guarantees. Full suite 135 passing, 100% coverage, black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)